### PR TITLE
Update AWS server address

### DIFF
--- a/lib/fipeapi.rb
+++ b/lib/fipeapi.rb
@@ -10,7 +10,7 @@ require_relative 'fipeapi/ano'
 require_relative 'fipeapi/valor'
 
 module FipeApi
-  API_URL = 'https://fipe-parallelum.rhcloud.com/api/v1'
+  API_URL = 'https://fipe.parallelum.com.br/api/v1'
   CARRO = 'carros'
   MOTO = 'motos'
   CAMINHAO = 'caminhoes'


### PR DESCRIPTION
  Alter API service URL to a private server, because the older server
  has been closed